### PR TITLE
New GitHub action + update in minimum python version required

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,10 +7,10 @@ name: Docker
 
 on:
   pull_request:
-    branches: [ "main" ]
-  
+    branches: ["main"]
+
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -18,10 +18,8 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Enable QEMU for cross-platform builds
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -45,7 +43,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: "v2.2.4"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,6 @@ name: Docker
 on:
   pull_request:
     branches: ["main"]
-
   release:
     types: [published]
 

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Test Python Build
+name: Test Python Build - Linux and macOS
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["published"]
 
 jobs:
   build:

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Test Python Build
 
 on:
   push:

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Test Python Build - Linux and macOS
+name: Test Python Build
 
 on:
   push:

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest
+          python -m pip install . --no-cache-dir
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -4,10 +4,10 @@
 name: Test Python Build
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    branches: ["published"]
+    branches: ["main"]
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,9 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Backsub - pixel-by-pixel channel subtraction tool for multiplexed immunofluorescence data
+[![PyPI](https://img.shields.io/pypi/v/backsub?style=flat-square)](https://pypi.org/project/backsub/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/backsub?style=flat-square)](https://pypi.org/project/backsub/)
+[![PyPI - License](https://img.shields.io/pypi/l/backsub?style=flat-square)](https://pypi.org/project/backsub/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/backsub?style=flat-square)](https://pypi.org/project/backsub/)
 
 Backsub performs pixel-by-pixel background subtraction between marker and background channels scaled by their respective exposure times. The outputs are saved as pyramidal OME-TIFF files. It was originally developed for data produced by the Lunaphore COMET platform and is fully compatible with the [MCMICRO](https://mcmicro.org) pipeline.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Marker_corrected = Marker_raw − Background × (Exposure_Marker / Exposure_Back
 
 ## Installation
 
-Backsub can be installed directly from PyPI, or run in a preconfigured Docker container. For development or container builds, a fixed-version Conda environment is provided.
+Backsub can be installed directly from PyPI, or run in a preconfigured Docker container. For development or container builds, a fixed-version Conda environment is provided.  
+Backsub requires Python >=3.11
 
 ### Option 1: Install from PyPI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
-    "Operating System :: Windows",
+    "Operating System :: Microsoft :: Windows",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,21 @@ name = "backsub"
 dynamic = ["version"]
 description = "Channel subtraction scaled by exposure times"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [
     { name="Krešimir Bestak", email="kbestak@gmail.com" }
 ]
 keywords = ["autofluorescence", "imaging", "immunofluorescence", "subtraction"]
 classifiers = [
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Operating System :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Windows",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License"
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Operating System :: Linux",
+    "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Operating System :: Windows",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Add python-build-package.yml action
- This action builds python binaries for linux, macOS and windows across multiple python versions 3.11 to 3.14

Update README.md
- Add sentence specifying minimum python requirements
- Add banners

Update pyproject.toml
- Updated minimum Python version requirement from >= 3.9 to  >=3.11
- Add pypi classifiers

Update python-publish.yml
- Updates  actions/checkout and actions/setup-python top @v6. This is important for upkeep, the previous versions would be soon deprecated. This change guarantees that the actions don't break soon. (Hopefully)

Update docker-publish.yml
- Updates  actions/checkout top v6 and docker/setup-qemu-action to v3. This is important for upkeep, the previous versions would be soon deprecated. This change guarantees that the actions don't break soon. (Hopefully)
- Lint the yml. 
